### PR TITLE
Adding ability to keep watermark permanently visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save videojs-watermark
 
 **position:** The location to place the watermark (top-left, top-right, bottom-left, bottom-right). Defaults to 'top-right'.
 
-**fadeTime:** The amount of time in milliseconds for the initial watermark fade. Defaults to 3000.
+**fadeTime:** The amount of time in milliseconds for the initial watermark fade. Defaults to 3000. To make watermark permanently visible, use `null`.
 
 **url:** A url to be linked to from the watermark. If the user clicks the watermark the video will be paused and the link will open in a new window.
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -78,6 +78,12 @@ const onPlayerReady = (player, options) => {
     return;
   }
   setupWatermark(player, options);
+
+  // Setup watermark autofade
+  if (options.fadeTime === null) {
+    return;
+  }
+
   player.on('play', () => fadeWatermark(options));
 };
 


### PR DESCRIPTION
Just pass an option `fadeTime: null`.

`undefined` doesn't work, as it's such value is ignored. See Lodash documentation: [_.merge](https://lodash.com/docs/4.15.0#merge)
