### PR TITLE
Updated plugin for videojs 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 sudo: false
+dist: trusty
 language: node_js
 node_js:
   - 'node'
-  - '4.2'
-  - '0.12'
-  - '0.10'
+  - 'lts/argon'
 
 before_script:
-
-  # Set up a virtual screen for Firefox.
+  # Check if the current version is equal to the major version for the env.
+  - 'export IS_INSTALLED="$(npm list video.js | grep "video.js@$VJS")"'
+  # We have to add semicolons to the end of each line in the if as Travis runs
+  # this all on one line.
+  - 'if [ -z "$IS_INSTALLED" ]; then
+      echo "INSTALLING video.js@>=$VJS.0.0-RC.0 <$(($VJS+1)).0.0";
+      npm i "video.js@>=$VJS.0.0-RC.0 <\$(($VJS+1)).0.0";
+    else
+      echo "video.js@$VJS ALREADY INSTALLED";
+    fi'
+  - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+env:
+  - VJS=5
+  - VJS=6
+
+addons:
+  firefox: latest
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable

--- a/index.html
+++ b/index.html
@@ -13,14 +13,17 @@
   </video>
   <ul>
     <li><a href="/test/">Run unit tests in browser.</a></li>
-    
+
   </ul>
   <script src="/node_modules/video.js/dist/video.js"></script>
   <script src="/dist/videojs-watermark.js"></script>
   <script>
     (function(window, videojs) {
       var player = window.player = videojs('videojs-watermark-player');
-      player.watermark();
+      player.watermark({
+        image: 'https://dotsub.com/static/players/beta/player-logo.png',
+        url: 'https://dotsub.com'
+      });
     }(window, window.videojs));
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test/"
   ],
   "dependencies": {
-    "video.js": "^5.9.2"
+    "video.js": "^6.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.35",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -107,7 +107,7 @@ const watermark = function(options) {
 };
 
 // Register the plugin with video.js.
-videojs.plugin('watermark', watermark);
+videojs.registerPlugin('watermark', watermark);
 
 // Include the version number.
 watermark.VERSION = '__VERSION__';

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -41,8 +41,8 @@ QUnit.test('registers itself with video.js', function(assert) {
   assert.expect(2);
 
   assert.strictEqual(
-    Player.prototype.watermark,
-    plugin,
+    typeof Player.prototype.watermark,
+    'function',
     'videojs-watermark plugin was registered'
   );
 
@@ -61,8 +61,8 @@ QUnit.test('does not add image if not configued', function(assert) {
   assert.expect(2);
 
   assert.strictEqual(
-    Player.prototype.watermark,
-    plugin,
+    typeof Player.prototype.watermark,
+    'function',
     'videojs-watermark plugin was registered'
   );
 
@@ -84,8 +84,8 @@ QUnit.test('does add image with correct path', function(assert) {
   assert.expect(5);
 
   assert.strictEqual(
-    Player.prototype.watermark,
-    plugin,
+    typeof Player.prototype.watermark,
+    'function',
     'videojs-watermark plugin was registered'
   );
 
@@ -128,8 +128,8 @@ QUnit.test('does add a link when URL is configured', function(assert) {
   assert.expect(6);
 
   assert.strictEqual(
-    Player.prototype.watermark,
-    plugin,
+    typeof Player.prototype.watermark,
+    'function',
     'videojs-watermark plugin was registered'
   );
 


### PR DESCRIPTION
* Updated to build with videojs 6.2.0
* Updated test registration test to 6.x format (see: [New Template](https://github.com/videojs/generator-videojs-plugin/blob/master/generators/app/templates/test/_plugin.test.js#L44)
* Migrated to `registerPlugin` since `plugin` is now depercated.
* Added logo and URL to root index.html for testing

Closes #11  